### PR TITLE
C11 - Account activation

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActivationsController < ApplicationController
+end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,2 +1,15 @@
 class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated && user.authenticated?(:activation, params[:id])
+      user.update_attribute(:activated, true)
+      user.update_attribute(:activated_at, Time.zone.now)
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -2,8 +2,7 @@ class AccountActivationsController < ApplicationController
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated && user.authenticated?(:activation, params[:id])
-      user.update_attribute(:activated, true)
-      user.update_attribute(:activated_at, Time.zone.now)
+      user.activate
       log_in user
       flash[:success] = "Account activated!"
       redirect_to user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,9 +5,16 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
-      log_in(@user)
-      params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
-      redirect_back_or @user
+      if @user.activated?
+        log_in(@user)
+        params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
+        redirect_back_or @user
+      else
+        message = "Account not activated."
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       flash.now[:danger] = "Invalid email/password combination"
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user, only: :destroy
 
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      UserMailer.account_activation(@user).deliver_now
+      @user.send_activation_email
       flash[:info] = "Please check your email to activate your account."
       redirect_to root_url
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in(@user)
-      flash[:success] = "Welcome to the app #{@user.name}"
-      redirect_to @user
+      UserMailer.account_activation(@user).deliver_now
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
     else
       render :new
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -22,7 +22,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in(user)
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,24 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,10 +5,9 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.account_activation.subject
   #
-  def account_activation
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account Activation"
   end
 
   # Subject can be set in your I18n file at config/locales/en.yml

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ApplicationRecord
   private
 
   def downcase_email
-    self.email = email.downcase
+    email.downcase!
   end
 
   def create_activation_digest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,9 +34,11 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  # Returns true if the given token matches the digest
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   def forget

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,17 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
 
+  # Activates an account
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
+  end
+
+  # Send activation email
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
   private
 
   def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,13 @@
 class User < ApplicationRecord
   # ApplicationRecord(abstract) inherits form ActiveRecord::Base
+  attr_accessor :remember_token, :activation_token
 
-  attr_accessor :remember_token
+  # Callbacks
+  before_save :downcase_email
+  before_create :create_activation_digest
 
   # Constants
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-
-  # Callbacks
-  before_save { email.downcase! }
 
   # Validations
   validates :name, presence: true, length: { maximum: 50 }
@@ -41,5 +41,16 @@ class User < ApplicationRecord
 
   def forget
     update_attribute(:remember_digest, nil)
+  end
+
+  private
+
+  def downcase_email
+    self.email = email.downcase
+  end
+
+  def create_activation_digest
+    self.activation_token = User.new_token
+    self.activation_digest = User.digest(activation_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,8 +47,7 @@ class User < ApplicationRecord
 
   # Activates an account
   def activate
-    update_attribute(:activated, true)
-    update_attribute(:activated_at, Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now)
   end
 
   # Send activation email

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,5 @@
+<h1>User#account_activation</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/account_activation.html.erb
+</p>

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,5 +1,7 @@
-<h1>User#account_activation</h1>
+<h1>Sample App</h1>
 
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/account_activation.html.erb
-</p>
+<p>Hi <%= @user.name %>,</p>
+
+<p>Welcome to the Sample App! Click on the link below to activate your account:</p>
+
+<%= link_to "Activate", edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,3 @@
+User#account_activation
+
+<%= @greeting %>, find me in app/views/user_mailer/account_activation.text.erb

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,3 +1,5 @@
-User#account_activation
+Hi <%= @user.name %>,
 
-<%= @greeting %>, find me in app/views/user_mailer/account_activation.text.erb
+Welcome to the Sample App! Click on the link below to activate your account:
+
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,15 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :test
 
   config.action_mailer.perform_caching = false
+
+  host = 'localhost:3000'
+
+  config.action_mailer.default_url_options = { host: host, protocol: 'http'}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,19 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  # host = '<your heroku app>.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: 'example.com' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
   resources :users
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20181008194830_add_activation_to_users.rb
+++ b/db/migrate/20181008194830_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_07_152646) do
+ActiveRecord::Schema.define(version: 2018_10_08_194830) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 2018_10_07_152646) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,9 @@ User.create!(
   email: 'example@railstutorial.org',
   password: 'foobar',
   password_confirmation: 'foobar',
-  admin: true
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now
 )
 
 99.times do |n|
@@ -24,6 +26,8 @@ User.create!(
     name: name,
     email: email,
     password: password,
-    password_confirmation: password
+    password_confirmation: password,
+    activated: true,
+    activated_at: Time.zone.now
   )
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -5,24 +5,32 @@ one:
   email: "michael@example.com"
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true,
+  activated_at: Time.zone.now
 
 two:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
   admin: false
+  activated: true,
+  activated_at: Time.zone.now
 
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
   admin: false
+  activated: true,
+  activated_at: Time.zone.now
 
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
   admin: false
+  activated: true,
+  activated_at: Time.zone.now
 
 <% 30.times do |n| %>
 user_<%= n %>:
@@ -30,4 +38,6 @@ user_<%= n %>:
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
   admin: false
+  activated: true,
+  activated_at: Time.zone.now
 <% end %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -52,6 +52,9 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       }
     end
     assert_equal 1, ActionMailer::Base.deliveries.size
+    # Note: assigns(:user) lets us access instance variables in the corresponding action,
+    # the Users controller’s create action defines an @user variable so can access it here.
+    # In other words: `user = @user`
     user = assigns(:user)
     assert_not user.activated?
     # Try to log in before activation

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -14,6 +14,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       }
     end
     assert_template 'users/new'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
   end
 
   test 'sign up error messages' do
@@ -46,8 +48,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       }
     end
     follow_redirect!
-    assert_template 'users/show'
-    assert_not flash.empty?
-    assert is_logged_in?
+    # assert_template 'users/show'
+    # assert_not flash.empty?
+    # assert is_logged_in?
   end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
   test 'invalid signup information' do
     get signup_path
     assert_no_difference 'User.count' do
@@ -35,7 +39,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'li.error-message'
   end
 
-  test 'valid signup information' do
+  test 'valid signup information with account activation' do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: {
@@ -47,9 +51,24 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
         }
       }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = assigns(:user)
+    assert_not user.activated?
+    # Try to log in before activation
+    log_in_as(user)
+    assert_not is_logged_in?
+    # Invalid activation token
+    get edit_account_activation_path("invalid_token", email: user.email)
+    assert_not is_logged_in?
+    # Valid token, wrong email
+    get edit_account_activation_path(user.activation_token, email: "wrong")
+    assert_not is_logged_in?
+    # Valid activation token
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
-    # assert_template 'users/show'
-    # assert_not flash.empty?
-    # assert is_logged_in?
+    assert_template 'users/show'
+    assert_not flash.empty?
+    assert is_logged_in?
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -3,7 +3,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
   def account_activation
-    UserMailer.account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,14 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    UserMailer.account_activation
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    mail = UserMailer.account_activation
+    assert_equal "Account activation", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -2,19 +2,14 @@ require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
   test "account_activation" do
-    mail = UserMailer.account_activation
-    assert_equal "Account activation", mail.subject
-    assert_equal ["to@example.org"], mail.to
-    assert_equal ["from@example.com"], mail.from
-    assert_match "Hi", mail.body.encoded
+    user = users(:one)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account Activation", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name, mail.body.encoded
+    assert_match user.activation_token, mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
   end
-
-  test "password_reset" do
-    mail = UserMailer.password_reset
-    assert_equal "Password reset", mail.subject
-    assert_equal ["to@example.org"], mail.to
-    assert_equal ["from@example.com"], mail.from
-    assert_match "Hi", mail.body.encoded
-  end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -77,6 +77,6 @@ class UserTest < ActiveSupport::TestCase
  end
 
  test "authenticated? should return false for a user with nil digest" do
-   assert_not @user.authenticated?('')
+   assert_not @user.authenticated?(:remember, '')
  end
 end


### PR DESCRIPTION
Chapter 11

> Like sessions, account activations can be modeled as a resource despite not being Active Record objects.
> Rails can generate Action Mailer actions and views to send email.
> Action Mailer supports both plain-text and HTML mail.
> As with ordinary actions and views, instance variables defined in mailer actions are available in mailer views.
> Account activations use a generated token to create a unique URL for activating users.
> Account activations use a hashed activation digest to securely identify valid activation requests.
> Both mailer tests and integration tests are useful for verifying the behavior of the User mailer.
> We can send email in production using SendGrid.

https://www.railstutorial.org/book/account_activation#sec-activation_what_we_learned_in_this_chapter